### PR TITLE
RSDEV-444: Upgrade digital-commons-data-java-client to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.0.0]
+- Spring 6 / Hibernate 6 / Jakarta migration (RSDEV-444)
+- Upgrade to rspace-parent 3.0.0
+
 ## [0.0.1]
 - Creation of the Digital Commons Data java client
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.rspace-os</groupId>
         <artifactId>rspace-parent</artifactId>
-        <version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
+        <version>3.0.0</version>
     </parent>
 
     <artifactId>digital-commons-data-java-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>com.github.rspace-os</groupId>
         <artifactId>rspace-parent</artifactId>
-        <version>2.0.1</version>
+        <version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
     </parent>
 
     <artifactId>digital-commons-data-java-client</artifactId>
-    <version>0.0.4</version>
+    <version>1.0.0</version>
 
     <repositories>
         <repository>

--- a/src/main/java/com/researchspace/dcd/client/DigitalCommonsDataClientImpl.java
+++ b/src/main/java/com/researchspace/dcd/client/DigitalCommonsDataClientImpl.java
@@ -49,7 +49,8 @@ public class DigitalCommonsDataClientImpl implements DigitalCommonsDataClient {
     try {
       deleteDataset(FAKE_ID);
     } catch (HttpClientErrorException clientEx) {
-      if (clientEx.getStatusCode().value() == 404) {
+      if (clientEx.getStatusCode().value() == 404
+          && clientEx.getResponseBodyAsString().contains("not found")) {
         return Boolean.TRUE;
       } else {
         return Boolean.FALSE;

--- a/src/main/java/com/researchspace/dcd/client/DigitalCommonsDataClientImpl.java
+++ b/src/main/java/com/researchspace/dcd/client/DigitalCommonsDataClientImpl.java
@@ -46,12 +46,10 @@ public class DigitalCommonsDataClientImpl implements DigitalCommonsDataClient {
   @Override
   public Boolean testConnection() {
     final String FAKE_ID = "FAKE_ID";
-    String expectedMsg =
-				"404 Not Found: \"{\"message\":\"Draft dataset '" + FAKE_ID + "' not found\"}\"";
     try {
       deleteDataset(FAKE_ID);
     } catch (HttpClientErrorException clientEx) {
-      if (expectedMsg.equals(clientEx.getMessage())) {
+      if (clientEx.getStatusCode().value() == 404) {
         return Boolean.TRUE;
       } else {
         return Boolean.FALSE;

--- a/src/test/java/com/researchspace/dcd/client/DigitalCommonsDataClientTest.java
+++ b/src/test/java/com/researchspace/dcd/client/DigitalCommonsDataClientTest.java
@@ -137,6 +137,18 @@ class DigitalCommonsDataClientTest {
   }
 
   @Test
+  public void testIsConnectionNotOpenWhenUnrelated404() {
+    mockServer.expect(requestTo(
+            containsString(
+                "https://api.data.mendeley.com/active-data-entities/datasets/drafts/FAKE_ID")))
+        .andRespond(withStatus(HttpStatusCode.valueOf(404))
+            .body("{\"message\":\"Not Found\"}"));
+
+    Boolean datasetDeleted = digitalCommonsDataClientImpl.testConnection();
+    assertFalse(datasetDeleted);
+  }
+
+  @Test
   public void testDepositFileSucceed() throws IOException {
 
     String fileDepositResponse = IOUtils.resourceToString("/json/fileDepositResponse.json",

--- a/src/test/java/com/researchspace/dcd/client/DigitalCommonsDataClientTest.java
+++ b/src/test/java/com/researchspace/dcd/client/DigitalCommonsDataClientTest.java
@@ -1,5 +1,6 @@
 package com.researchspace.dcd.client;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -25,7 +26,7 @@ import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.HttpClientErrorException;
@@ -78,7 +79,7 @@ class DigitalCommonsDataClientTest {
         HttpClientErrorException.class,
         () -> digitalCommonsDataClientImpl.createDataset(submission)
     );
-    assertEquals("401 Unauthorized: [no body]", thrown.getMessage());
+    assertThat(thrown.getMessage(), containsString("401 Unauthorized"));
 
   }
 
@@ -108,7 +109,7 @@ class DigitalCommonsDataClientTest {
         HttpClientErrorException.class,
         () -> digitalCommonsDataClientImpl.deleteDataset(datasetId)
     );
-    assertEquals("401 Unauthorized: [no body]", thrown.getMessage());
+    assertThat(thrown.getMessage(), containsString("401 Unauthorized"));
 
   }
 
@@ -117,7 +118,7 @@ class DigitalCommonsDataClientTest {
     mockServer.expect(requestTo(
             containsString(
                 "https://api.data.mendeley.com/active-data-entities/datasets/drafts/FAKE_ID")))
-        .andRespond(withStatus(HttpStatus.NOT_FOUND)
+        .andRespond(withStatus(HttpStatusCode.valueOf(404))
             .body("{\"message\":\"Draft dataset 'FAKE_ID' not found\"}"));
 
     Boolean datasetDeleted = digitalCommonsDataClientImpl.testConnection();
@@ -193,7 +194,7 @@ class DigitalCommonsDataClientTest {
         HttpClientErrorException.class,
         () -> digitalCommonsDataClientImpl.depositFile(dataset, "example.txt ", file)
     );
-    assertEquals("401 Unauthorized: [no body]", thrown.getMessage());
+    assertThat(thrown.getMessage(), containsString("401 Unauthorized"));
 
   }
 


### PR DESCRIPTION
Upgrade digital-commons-data-java-client to 1.0.0 for Spring 6 / Jakarta migration (RSDEV-444).

Bumps parent pom and switches `testConnection()` to branch on the numeric status code instead of the Spring exception message text (whose format changed in Spring 6).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
